### PR TITLE
fix: use constant for min length

### DIFF
--- a/src/main/kotlin/org/sqids/Sqids.kt
+++ b/src/main/kotlin/org/sqids/Sqids.kt
@@ -573,7 +573,7 @@ class Sqids(private var alphabet: String = DEFAULT_ALPHABET, private val minLeng
             throw IllegalArgumentException("Alphabet cannot contain multibyte characters")
         }
 
-        if(alphabet.length < 3) {
+        if(alphabet.length < MINIMUM_LENGTH) {
             throw IllegalArgumentException("Alphabet length must be at least $MINIMUM_LENGTH")
         }
 


### PR DESCRIPTION
As per title, replaced hardcoded minimum length with defined constant